### PR TITLE
Generalize GHCGenerically1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20210912
+# version: 0.13.20211030
 #
-# REGENDATA ("0.13.20210912",["github","linear-generics.cabal"])
+# REGENDATA ("0.13.20211030",["github","linear-generics.cabal"])
 #
 name: Haskell-CI
 on:
@@ -26,11 +26,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.0.20210821
+          - compiler: ghc-9.2.1
             compilerKind: ghc
-            compilerVersion: 9.2.0.20210821
+            compilerVersion: 9.2.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
@@ -43,10 +43,10 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.16.2/x86_64-linux-ghcup-0.1.16.2 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.6.0.0
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -62,12 +62,12 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
           echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -96,17 +96,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          EOF
-          fi
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -156,9 +145,6 @@ jobs:
           package linear-generics
             ghc-options: -Werror
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(linear-generics)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2
+* The `Generic1` instance for `Generically1` no longer uses
+  `GHC.Generics.Generic1`; it now uses `GHC.Generics.Generic` instead.  This
+  allows far more instances to be derived.
+
 # 0.1.0.1
 * Make `Generic1` deriving properly polykinded. There was an old kind check
   that has not been valid for a long time.

--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ This library is organized as follows:
   deriving instances of `Generic(1)`.
 
 * `Generics.Linear.Unsafe.ViaGHCGenerics` offers `DerivingVia` targets to
-  derive `Generic` and (some) `Generic1` instances from their
-  `GHC.Generics` counterparts. Because these instances necessarily
-  use unsafe coercions, their use will likely inhibit full optimization
-  of code using them (see
+  derive both `Generic` and `Generic1` instances from `GHC.Generics.Generic`.
+  Because these instances necessarily use unsafe coercions, their
+  use will likely inhibit full optimization of code using them (see
   [this wiki page](https://gitlab.haskell.org/ghc/ghc/-/wikis/linear-types/multiplicity-evidence)
   for more on the GHC internals, along with commentary in `Unsafe.Coerce`).
 

--- a/linear-generics.cabal
+++ b/linear-generics.cabal
@@ -1,5 +1,5 @@
 name:                   linear-generics
-version:                0.1.0.1
+version:                0.2
 synopsis:               Generic programming library for generalised deriving.
 description:
   This package offers a version of
@@ -32,10 +32,10 @@ description:
     deriving instances of @Generic(1)@.
   .
   * "Generics.Linear.Unsafe.ViaGHCGenerics" offers @DerivingVia@ targets to
-    derive @Generic@ and (some) @Generic1@ instances from their
-    "GHC.Generics" counterparts. Because these instances necessarily
-    use unsafe coercions, their use will likely inhibit full optimization
-    of code using them.
+    derive @Generic@ and @Generic1@ instances from
+    @"GHC.Generics".'GHC.Generics.Generic'@. Because these instances necessarily
+    use unsafe coercions, their use will likely inhibit full optimization of
+    code using them.
   .
   Educational code: the educational modules exported by
   <https://hackage.haskell.org/package/generic-deriving generic-deriving>
@@ -60,7 +60,7 @@ stability:              experimental
 build-type:             Simple
 cabal-version:          >= 1.10
 tested-with:            GHC == 9.0.1
-                      , GHC == 9.2.*
+                      , GHC == 9.2.1
 extra-source-files:     CHANGELOG.md
                       , README.md
 

--- a/src/Generics/Linear/Unsafe/ViaGHCGenerics.hs
+++ b/src/Generics/Linear/Unsafe/ViaGHCGenerics.hs
@@ -1,33 +1,20 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LinearTypes #-}
-{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE Unsafe #-}
 
--- | 'DerivingVia' targets to instantiate 'Generic' and 'Generic1' using
--- @"GHC.Generics".'G.Generic'@ and @"GHC.Generics".'G.Generic1'@,
--- respectively.
+-- | 'DerivingVia' targets to instantiate 'Generic' and 'Generic1',
+-- both using @"GHC.Generics".'G.Generic'@.
 --
 -- === Caution
 
@@ -44,7 +31,7 @@ module Generics.Linear.Unsafe.ViaGHCGenerics
   , GHCGenerically1(..)
   ) where
 import Data.Coerce (Coercible, coerce)
-import Data.Kind (Constraint, Type)
+import Data.Kind (Type)
 import Generics.Linear
 import qualified GHC.Generics as G
 import Unsafe.Coerce
@@ -84,82 +71,6 @@ instance G.Generic a => Generic (GHCGenerically a) where
   to = toLinear (GHCGenerically #. G.to)
   from = toLinear (G.from .# unGHCGenerically)
 
--- | When @a@ is an instance of @"GHC.Generics".'G.Generic1'@, and its 'G.Rep1'
--- contains no compositions, @GHCGenerically1 a@ is an instance of 'Generic1'.
---
--- === Warning
---
--- @GHCGenerically1@ is intended for use as a 'DerivingVia' target.
--- Most other uses of its 'Generic1' instance will be quite wrong.
---
--- @GHCGenerically1@ /must not/ be used with datatypes that have
--- nonlinear or linearity-polymorphic fields. Doing so will produce
--- completely bogus results, breaking the linearity rules.
---
--- @GHCGenerically1@ is otherwise safe to use with /derived/
--- @"GHC.Generics".'G.Generic1'@ instances, which are linear. If
--- you choose to use it with a hand-written instance, you should
--- check that the underlying instance is linear.
---
--- === Example
---
--- @
--- data Foo a = Bar a (Either Int a) | Baz (Maybe a) Int
---   deriving stock (Show, "GHC.Generics".'G.Generic1')
---   deriving 'Generic1' via GHCGenerically1 Foo
--- @
-type GHCGenerically1 :: forall k. (k -> Type) -> k -> Type
-newtype GHCGenerically1 f a = GHCGenerically1 { unGHCGenerically1 :: f a }
-
-instance (G.Generic1 f, Repairable ('ShowType f) (G.Rep1 f)) => Generic1 (GHCGenerically1 f) where
-  type Rep1 (GHCGenerically1 f) = Repair (G.Rep1 f)
-
-  -- Why do we use 'unsafeCoerce' for these rather than just 'toLinear'?
-  -- While @Rec1 f@ and @Par1 :.: f@ are represented the same way in
-  -- memory, they are not @Coercible@. So we'd have to tear down the
-  -- representation and build it back up again. Since we need an unsafe
-  -- coercion anyway (in 'toLinear'), there's no operational benefit.
-  -- That would shrink the trusted code base slightly, in a sense, but
-  -- I don't think it's worth it.
-
-  to1 :: forall a m. Rep1 (GHCGenerically1 f) a %m-> GHCGenerically1 f a
-  to1 = unsafeCoerce (GHCGenerically1 #. G.to1 @_ @f @a)
-
-  from1 :: forall a m. GHCGenerically1 f a %m-> Rep1 (GHCGenerically1 f) a
-  from1 = unsafeCoerce (G.from1 @_ @f @a .# unGHCGenerically1)
-
--- | A @"GHC.Generics".'G.Rep1'@ is @Repairable@ if it contains no
--- compositions. The 'ErrorMessage' argument should be 'ShowType'
--- of the type whose representation this is.
-type Repairable :: forall k. ErrorMessage -> (k -> Type) -> Constraint
-class Repairable tn (grep1 :: k -> Type) where
-  -- | Convert a @"GHC.Generics".'G.Rep1'@ representation into a 'Rep1'
-  -- representation.
-  type Repair grep1 :: k -> Type
-instance Repairable tn f => Repairable tn (M1 i c f) where
-  type Repair (M1 i c f) = M1 i c (Repair f)
-instance Repairable tn (G.Rec1 f) where
-  type Repair (G.Rec1 f) = Par1 :.: f
-instance Repairable tn (K1 i c) where
-  type Repair (K1 i c) = K1 i c
-instance Repairable tn Par1 where
-  type Repair Par1 = Par1
-instance (Repairable tn f, Repairable tn g) => Repairable tn (f :*: g) where
-  type Repair (f :*: g) = Repair f :*: Repair g
-instance (Repairable tn f, Repairable tn g) => Repairable tn (f :+: g) where
-  type Repair (f :+: g) = Repair f :+: Repair g
-instance Repairable tn U1 where
-  type Repair U1 = U1
-instance Repairable tn V1 where
-  type Repair V1 = V1
-instance Repairable tn (URec r) where
-  type Repair (URec r) = URec r
-instance
-     TypeError ('Text "Could not derive linear Generic1 from GHC Generic1 for type" ':$$:
-                tn ':<>: 'Text "." ':$$: 'Text "Its Rep1 instance includes composition.")
-  => Repairable tn (f :.: g) where
-  type Repair (_ :.: _) = Any
-
 -- Stolen from linear-base, but without some polymorphism
 -- we don't need here.
 
@@ -178,3 +89,95 @@ infixr 9 #.
 infixl 8 .#
 (.#) :: Coercible a b => (b -> c) -> p a b -> a -> c
 f .# _ = coerce f
+
+-- --------
+-- Generic1
+-- --------
+
+-- | When @f a@ is an instance of @"GHC.Generics".'G.Generic'@
+-- for all @a@, @GHCGenerically1 f@ is an instance of 'Generic1'.
+--
+-- === Warning
+--
+-- @GHCGenerically1@ is intended for use as a 'DerivingVia' target.
+-- Most other uses of its 'Generic1' instance will be quite wrong.
+--
+-- @GHCGenerically1@ /must not/ be used with datatypes that have
+-- nonlinear or linearity-polymorphic fields. Doing so will produce
+-- completely bogus results, breaking the linearity rules.
+--
+-- @GHCGenerically1@ is otherwise safe to use with /derived/
+-- @"GHC.Generics".'G.Generic'@ instances, which are linear. If
+-- you choose to use it with a hand-written instance, you should
+-- check that the underlying instance is linear.
+--
+-- === Example
+--
+-- @
+-- data Foo a = Bar a (Either Int a) | Baz (Maybe a) Int
+--   deriving stock (Show, "GHC.Generics".'G.Generic')
+--   deriving 'Generic1' via GHCGenerically1 Foo
+-- @
+type GHCGenerically1 :: forall k. (k -> Type) -> k -> Type
+newtype GHCGenerically1 f a = GHCGenerically1 { unGHCGenerically1 :: f a }
+
+instance forall k (f :: k -> Type).
+  (forall (a :: k). G.Generic (f a)) => Generic1 (GHCGenerically1 f) where
+  type Rep1 (GHCGenerically1 (f :: k -> Type)) = MakeRep1 @k (G.Rep ((MarkOtherPars f) (LastPar :: k)))
+
+  -- Why do we use unsafeCoerce here? While @G.Rep (f a)@ and @Rep1 f a@ are
+  -- the same in memory, they're not (generally) Coercible. This largely has to
+  -- do with the "modular" way GHC handles Coercible constraints for datatypes
+  -- (as opposed to newtypes), including (:+:) and (:*:). Even if
+  --
+  --   f `Coercible` f' and g `Coercible` g',
+  --
+  -- we *don't* have
+  --
+  --   (f :+: g) `Coercible` (f' :+: g').
+  --
+  -- So we either need to use an unsafe coercion or completely tear down and
+  -- rebuild the representation value.  Since we need an unsafe coercion to get
+  -- linearity anyway, there's little to be gained by doing the latter.
+
+  to1 :: forall a m. Rep1 (GHCGenerically1 f) a %m-> GHCGenerically1 f a
+  to1 = unsafeCoerce (G.to :: G.Rep (f a) Any -> f a)
+
+  from1 :: forall a m. GHCGenerically1 f a %m-> Rep1 (GHCGenerically1 f) a
+  from1 = unsafeCoerce (G.from :: f a -> G.Rep (f a) Any)
+
+-- This marking technique is inspired by Csongor Kiss's `GenericN`, part of his
+-- generic-lens package family.
+
+data family LastPar :: k
+data family OtherPar :: k -> k
+
+type MakeRep1 :: forall k. (Type -> Type) -> k -> Type
+type family MakeRep1 (rep :: Type -> Type) :: k -> Type where
+  MakeRep1 (M1 i c f) = M1 i c (MakeRep1 f)
+  MakeRep1 (x :+: y) = MakeRep1 x :+: MakeRep1 y
+  MakeRep1 (x :*: y) = MakeRep1 x :*: MakeRep1 y
+  MakeRep1 U1 = U1
+  MakeRep1 V1 = V1
+  MakeRep1 (Rec0 c) = MakeRep1Field (Rec0 (Unmark c)) Par1 c
+
+type MarkOtherPars :: forall k. k -> k
+type family MarkOtherPars (f :: k) :: k where
+  MarkOtherPars ((f :: j -> k) (a :: j)) = MarkOtherPars f (OtherPar a)
+  MarkOtherPars f = f
+
+type Unmark :: forall k. k -> k
+type family Unmark (f :: k) :: k where
+  Unmark LastPar = TypeError ('Text "Cannot create Generic1 instance: the last parameter appears in an invalid location.")
+  Unmark (OtherPar a) = a
+  Unmark ((f :: j -> k) (a :: j)) = Unmark f (Unmark a)
+  Unmark a = a
+
+type MakeRep1Field :: forall j k. (k -> Type) -> (j -> Type) -> j -> k -> Type
+type family MakeRep1Field fk acc c where
+  -- Watch out! Order matters here. The third clause will match
+  -- OtherPar _ as well, and that's no good.
+  MakeRep1Field fk (acc :: k -> Type) (LastPar :: k) = acc
+  MakeRep1Field fk (_ :: b -> Type) (OtherPar _) = fk
+  MakeRep1Field fk (acc :: b -> Type) ((f :: a -> b) (x :: a)) = MakeRep1Field fk (acc :.: Unmark f) x
+  MakeRep1Field fk _ _ = fk


### PR DESCRIPTION
Instead of deriving `Generically1` via `GHC.Generics.Generic1`, derive
it from `GHC.Generics.Generic`. I demonstrated a safe/principled way to
do that (without linear types) in [this gist](https://gist.github.com/treeowl/7cddf019b7154b08987e1024959103ec).

Unlike `GHC.Generics.Generically1`, our `Generic1` uses a representation
that's operationally *identical* to the `Generic` one. Since we're being
unsafe anyway, we can just `unsafeCoerce` `to` and `from` to do what
we want.