### PR TITLE
GHC 9.4: Relax template-haskell version bounds

### DIFF
--- a/linear-generics.cabal
+++ b/linear-generics.cabal
@@ -90,7 +90,7 @@ library
   build-depends:        base >= 4.15 && < 5
                       , containers       >= 0.5.9 && < 0.7
                       , ghc-prim                     < 1
-                      , template-haskell >= 2.16  && < 2.19
+                      , template-haskell >= 2.16  && < 2.20
                       , th-abstraction   >= 0.4   && < 0.5
 
   default-language:     Haskell2010
@@ -128,7 +128,7 @@ test-suite spec
   build-depends:        base             >= 4.15  && < 5
                       , linear-generics
                       , hspec            >= 2    && < 3
-                      , template-haskell >= 2.16  && < 2.19
+                      , template-haskell >= 2.16  && < 2.20
   build-tool-depends:   hspec-discover:hspec-discover
   hs-source-dirs:       tests
   default-language:     Haskell2010


### PR DESCRIPTION
This allows linear-generics (and linear-base) to compile on 9.4 without conflicts

It builds (-O1 and -O2) without issues on my machine and passes all tests from `cabal run spec`