### PR TITLE
Bump template-haskell and th-abstraction for GHC 9.6.1, update CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230211
+# version: 0.15.20230312
 #
-# REGENDATA ("0.15.20230211",["github","linear-generics.cabal"])
+# REGENDATA ("0.15.20230312",["github","linear-generics.cabal"])
 #
 name: Haskell-CI
 on:
@@ -28,19 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.0.20230128
+          - compiler: ghc-9.6.1
             compilerKind: ghc
-            compilerVersion: 9.6.0.20230128
+            compilerVersion: 9.6.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.4.4
             compilerKind: ghc
             compilerVersion: 9.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.6
+          - compiler: ghc-9.2.7
             compilerKind: ghc
-            compilerVersion: 9.2.6
+            compilerVersion: 9.2.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -57,9 +57,8 @@ jobs:
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -75,12 +74,12 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
           echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -109,18 +108,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -174,9 +161,6 @@ jobs:
           package linear-generics
             ghc-options: -Werror
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(linear-generics)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,4 +2,3 @@ distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
 local-ghc-options:      -Werror
-ghcup-jobs:             >=8.10

--- a/linear-generics.cabal
+++ b/linear-generics.cabal
@@ -93,7 +93,7 @@ library
                       , containers       >= 0.5.9 && < 0.7
                       , ghc-prim                     < 1
                       , template-haskell >= 2.16  && < 2.20
-                      , th-abstraction   >= 0.4   && < 0.5
+                      , th-abstraction   >= 0.5   && < 0.6
 
   default-language:     Haskell2010
   default-extensions:   KindSignatures

--- a/linear-generics.cabal
+++ b/linear-generics.cabal
@@ -60,7 +60,7 @@ stability:              experimental
 build-type:             Simple
 cabal-version:          >= 1.10
 tested-with:            GHC == 9.0.2
-                      , GHC == 9.2.6
+                      , GHC == 9.2.7
                       , GHC == 9.4.4
                       , GHC == 9.6.1
 extra-source-files:     CHANGELOG.md
@@ -92,7 +92,7 @@ library
   build-depends:        base >= 4.15 && < 5
                       , containers       >= 0.5.9 && < 0.7
                       , ghc-prim                     < 1
-                      , template-haskell >= 2.16  && < 2.20
+                      , template-haskell >= 2.16  && < 2.21
                       , th-abstraction   >= 0.5   && < 0.6
 
   default-language:     Haskell2010
@@ -127,10 +127,10 @@ test-suite spec
                         Generics.Deriving.Traversable
                         Generics.Deriving.TraversableConf
                         Generics.Deriving.Uniplate
-  build-depends:        base             >= 4.15  && < 5
+  build-depends:        base
                       , linear-generics
                       , hspec            >= 2    && < 3
-                      , template-haskell >= 2.16  && < 2.20
+                      , template-haskell
   build-tool-depends:   hspec-discover:hspec-discover
   hs-source-dirs:       tests
   default-language:     Haskell2010

--- a/src/Generics/Linear/TH/Internal.hs
+++ b/src/Generics/Linear/TH/Internal.hs
@@ -26,7 +26,7 @@ import           Language.Haskell.TH.Datatype
 import           Language.Haskell.TH.Datatype.TyVarBndr
 import           Language.Haskell.TH.Lib
 import           Language.Haskell.TH.Ppr (pprint)
-import           Language.Haskell.TH.Syntax
+import           Language.Haskell.TH.Syntax hiding (Extension (..))
 
 -------------------------------------------------------------------------------
 -- Assorted utilities
@@ -325,14 +325,15 @@ reifyDataInfo name = do
                      fail (ns ++ " Could not reify " ++ nameBase name)
                      `recover`
                      reifyDatatype name
-    let variant_ = case variant of
-                     Datatype        -> Datatype_
-                     Newtype         -> Newtype_
+    variant_ <- case variant of
+                     Datatype        -> pure Datatype_
+                     Newtype         -> pure Newtype_
                      -- This isn't total, but the API requires that the data
                      -- family instance have at least one constructor anyways,
                      -- so this will always succeed.
-                     DataInstance    -> DataInstance_    $ head cons
-                     NewtypeInstance -> NewtypeInstance_ $ head cons
+                     DataInstance    -> pure $ DataInstance_ (head cons)
+                     NewtypeInstance -> pure $ NewtypeInstance_ (head cons)
+                     TypeData -> fail $ "Cannot derive Generic instances for TypeData " ++ nameBase name
     checkDataContext parentName ctxt
     pure (parentName, tys, cons, variant_)
   where


### PR DESCRIPTION
CI run at: https://github.com/andreasabel/linear-generics/actions/runs/4478302896/jobs/7870903370
Failing because of ` -Werror=incomplete-patterns`:
https://github.com/andreasabel/linear-generics/actions/runs/4478302896/jobs/7870903540#step:18:31
```
src/Generics/Linear/TH/Internal.hs:328:20: error: [-Wincomplete-patterns, -Werror=incomplete-patterns]
    Pattern match(es) are non-exhaustive
    In a case alternative:
        Patterns of type ‘DatatypeVariant’ not matched: TypeData
    |
    |     let variant_ = case variant of
    |                    ^^^^^^^^^^^^^^^...
```
@RyanGlScott @treeowl Do you want to fix this warning before releasing a GHC-9.6 compatible version to hackage?
(It is a bit odd that the [released version says `tested-with: GHC == 9.6.1`](https://github.com/linear-generics/linear-generics/blob/d43360e646cf2c0a510b5ea538c3d590a5b12722/linear-generics.cabal#L65) but does not support it.)