### PR TITLE
Add inlining pragmas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 * Produce an orderly error message if someone gives us `type data`.
 * Produce an error message much more eagerly when someone tries to
   use `GHCGenerically1` with an improperly shaped type.
+* Place `INLINE [1]` pragmas on `from` and `to` implementations when types
+  don't have too many constructors or fields, following the heuristics GHC now
+  uses for `Generic` deriving.
 
 # 0.2.1
 * Add a `Generic` instance for `Data.Void.Void`.

--- a/src/Generics/Linear/TH.hs
+++ b/src/Generics/Linear/TH.hs
@@ -168,9 +168,30 @@ deriveInstCommon genericName repName gClass fromName toName n = do
     fcs = mkBody mkFrom
     tcs = mkBody mkTo
 
+    inline_pragmas
+      | inlining_useful cons
+      = map (\fun_name -> pragInlD fun_name Inline FunLike (FromPhase 1)) [fromName, toName]
+      | otherwise
+      = []
   fmap (:[]) $
     instanceD (cxt []) (conT genericName `appT` return origSigTy)
-                         [return tyIns, funD fromName fcs, funD toName tcs]
+                       (inline_pragmas ++ [return tyIns, funD fromName fcs, funD toName tcs])
+
+  where
+    -- Adapted from inlining_useful in GHC.Tc.Deriv.Generics.mkBindsRep in the GHC
+    -- source code:
+    --
+    -- https://gitlab.haskell.org/ghc/ghc/-/blob/80729d96e47c99dc38e83612dfcfe01cf565eac0/compiler/GHC/Tc/Deriv/Generics.hs#L368-386
+    inlining_useful cons
+      | ncons <= 1  = True
+      | ncons <= 4  = max_fields <= 5
+      | ncons <= 8  = max_fields <= 2
+      | ncons <= 16 = max_fields <= 1
+      | ncons <= 24 = max_fields == 0
+      | otherwise   = False
+      where
+        ncons      = length cons
+        max_fields = maximum $ map (length . constructorFields) cons
 
 repType :: GenericTvbs
         -> DatatypeVariant_


### PR DESCRIPTION
Recent GHC versions have added `INLINE [1]` pragmas to derived `Generic` method definitions when there aren't "too many" constructors or fields. Do the same here.