### PR TITLE
Compatibility with th-abstraction 0.6

### DIFF
--- a/linear-generics.cabal
+++ b/linear-generics.cabal
@@ -99,7 +99,7 @@ library
                       , containers       >= 0.5.9 && < 0.7
                       , ghc-prim                     < 1
                       , template-haskell >= 2.16  && < 2.21
-                      , th-abstraction   >= 0.5   && < 0.6
+                      , th-abstraction   >= 0.5   && < 0.7
 
   default-language:     Haskell2010
   default-extensions:   KindSignatures


### PR DESCRIPTION
As spotted by commercialhaskell/stackage#7074,  there's been a new release of th-abstraction.

As far as I could tell, the tests pass with the new version, so I'm just bumping the upper bound.

I guess we can make a revision in Hackage for this, no need for a release.