### PR TITLE
Linear-generics is compatible with th-abstraction 0.7

### DIFF
--- a/linear-generics.cabal
+++ b/linear-generics.cabal
@@ -100,7 +100,7 @@ library
                       , containers       >= 0.5.9 && < 0.7
                       , ghc-prim                     < 1
                       , template-haskell >= 2.16  && < 2.23
-                      , th-abstraction   >= 0.5   && < 0.7
+                      , th-abstraction   >= 0.5   && < 0.8
 
   default-language:     Haskell2010
   default-extensions:   KindSignatures


### PR DESCRIPTION
Th-abstraction 0.7 was just released. I checked and upgraded the bound.

See commercialhaskell/stackage#7352 .