### PR TITLE
Basic cleanup: fix CI, and test with 9.10.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.17.20231106
+# version: 0.18.1
 #
-# REGENDATA ("0.17.20231106",["github","linear-generics.cabal"])
+# REGENDATA ("0.18.1",["github","linear-generics.cabal"])
 #
 name: Haskell-CI
 on:
@@ -23,11 +23,16 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.1
+            compilerKind: ghc
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.8.1
             compilerKind: ghc
             compilerVersion: 9.8.1
@@ -60,7 +65,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,4 +1,4 @@
-distribution:           bionic
+distribution:           jammy
 no-tests-no-benchmarks: False
 unconstrained:          False
 local-ghc-options:      -Werror

--- a/linear-generics.cabal
+++ b/linear-generics.cabal
@@ -70,6 +70,7 @@ tested-with:            GHC == 9.0.2
                       , GHC == 9.4.4
                       , GHC == 9.6.1
                       , GHC == 9.8.1
+                      , GHC == 9.10.1
 extra-source-files:     CHANGELOG.md
                       , README.md
 


### PR DESCRIPTION
There was some conflict between the bionic image that we were using and the environment in which the checkout action runs, so we were not able to even check the code out in Github action. Rather embarrassing.

We've been supporting GHC 9.10, but didn't test, so it was a good opportunity to add it to the matrix.

---

What I was really set to do was to upgrade to supporting 9.12 (and its template Haskell). See commercialhaskell/stackage#7718. But CI wouldn't work. So I fixed CI first.