### PR TITLE
Bump compatible GHC version to 9.14

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.1
             compilerKind: ghc
             compilerVersion: 9.12.1
@@ -72,12 +77,12 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.40.0/x86_64-linux-ghcup-0.1.40.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.2/x86_64-linux-ghcup-0.1.50.2 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |

--- a/linear-generics.cabal
+++ b/linear-generics.cabal
@@ -72,6 +72,7 @@ tested-with:            GHC == 9.0.2
                       , GHC == 9.8.1
                       , GHC == 9.10.1
                       , GHC == 9.12.1
+                      , GHC == 9.14.1
 extra-source-files:     CHANGELOG.md
                       , README.md
 
@@ -99,9 +100,9 @@ library
                         Generics.Linear.Instances.Template_haskell
 
   build-depends:        base >= 4.15 && < 5
-                      , containers       >= 0.5.9 && < 0.8
+                      , containers       >= 0.5.9 && < 0.9
                       , ghc-prim                     < 1
-                      , template-haskell >= 2.16  && < 2.24
+                      , template-haskell >= 2.16  && < 2.25
                       , th-abstraction   >= 0.5   && < 0.8
 
   default-language:     Haskell2010


### PR DESCRIPTION
Bump GHC/Template Haskell to the latest version. Based on the changelog I'm hoping we don't have to change anything, but I'll let the CI decide. (See commercialhaskell/stackage#7918)